### PR TITLE
Support Ruby 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,6 @@ gem 'kramdown-parser-gfm'
 
 # For testing output
 gem 'html-proofer'
+
+# For local Ruby 3 support; works around https://github.com/github/pages-gem/issues/752
+gem "webrick", "~> 1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,7 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.7)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
+    webrick (1.7.0)
     yell (2.2.2)
 
 PLATFORMS
@@ -86,6 +87,7 @@ DEPENDENCIES
   jekyll (= 3.9)
   kramdown-parser-gfm
   rake
+  webrick (~> 1.7)
 
 BUNDLED WITH
    1.17.3

--- a/Rakefile
+++ b/Rakefile
@@ -8,6 +8,12 @@ end
 
 task :dependencies do
   sh('bundle install --path gems')
+
+  # Fix pathutil on Ruby 3; works around https://github.com/envygeeks/pathutil/pull/5
+  # as suggested by https://stackoverflow.com/a/73909894/67873
+  pathutil_path = `bundle exec gem which pathutil`.chomp()
+  content = File.read(pathutil_path).gsub(', kwd', ', **kwd')
+  File.write(pathutil_path, content)
 end
 
 file '_sass/brand/.git' do


### PR DESCRIPTION
This ports the changes from https://github.com/srobo/website/pull/473.

This isn't officially supported by Jekyll and is a bit hacky, so I'm deliberately not documenting the support, however as recent Ubuntu versions now ship with Ruby 3 (not 2.7) and Jekyll isn't showing any signs of moving towards supporting Ruby 3 we're not left with many alternatives.